### PR TITLE
feat!: add RedisStorage driver

### DIFF
--- a/.github/workflows/php81.yaml
+++ b/.github/workflows/php81.yaml
@@ -4,7 +4,12 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, dev ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     name: Run Tests
@@ -21,6 +26,3 @@ jobs:
       coverage-file: 'php-8.1-coverage.xml'
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-    
-        
-          

--- a/.github/workflows/php82.yaml
+++ b/.github/workflows/php82.yaml
@@ -4,7 +4,12 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, dev ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     name: Run Tests
@@ -22,6 +27,3 @@ jobs:
       coverage-file: 'php-8.2-coverage.xml'
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-    
-        
-          

--- a/.github/workflows/php83.yaml
+++ b/.github/workflows/php83.yaml
@@ -2,21 +2,21 @@ name: Build PHP 8.3
 
 on:
   push:
-    branches: [ main, dev ]
+    branches: [ main ]
   pull_request:
     branches: [ main, dev ]
-env:
-  OPERATING_SYS: ubuntu-latest
-  PHP_VERSION: 8.3
-jobs:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
   test:
     name: Run Tests
     uses: WebFiori/workflows/.github/workflows/test-php.yaml@v1.2.1
     with:
       php-version: '8.3'
       phpunit-config: 'tests/phpunit10.xml'
-            
 
   code-coverage:
     name: Coverage
@@ -26,7 +26,7 @@ jobs:
       php-version: '8.3'
       coverage-file: 'php-8.3-coverage.xml'
     secrets:
-      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}  
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   code-quality:
     name: Code Quality
@@ -34,7 +34,7 @@ jobs:
     uses: WebFiori/workflows/.github/workflows/quality-sonarcloud.yaml@v1.2.1
     secrets:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-          
+
   release-prod:
     name: Prepare Production Release Branch / Publish Release
     needs: [code-coverage, code-quality]

--- a/.github/workflows/php84.yaml
+++ b/.github/workflows/php84.yaml
@@ -4,7 +4,12 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, dev ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     name: Run Tests
@@ -12,6 +17,33 @@ jobs:
     with:
       php-version: '8.4'
       phpunit-config: "tests/phpunit10.xml"
+
+  test-redis:
+    name: Run Redis Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    services:
+      redis:
+        image: redis:7
+        ports:
+          - 6379:6379
+        options: --health-cmd "redis-cli ping" --health-interval 10s --health-timeout 5s --health-retries 5
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup PHP 8.4
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.4'
+          extensions: redis
+          tools: composer
+          coverage: none
+
+      - name: Install Dependencies
+        run: composer install --prefer-source --no-interaction
+
+      - name: Run Redis Tests
+        run: vendor/bin/phpunit -c tests/phpunit10.xml --group redis
 
   code-coverage:
     name: Coverage
@@ -22,6 +54,3 @@ jobs:
       coverage-file: 'php-8.4-coverage.xml'
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-    
-        
-          

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ A simple, secure, and highly customizable caching engine for PHP. This library p
 - **Static facade** (`CacheFacade`) for quick usage without DI
 - **Time-based caching** with configurable TTL (Time-to-Live)
 - **Built-in encryption** for sensitive data protection
-- **Multiple storage backends** (File-based included, extensible via `Storage` interface)
+- **Multiple storage backends** (File-based and Redis included, extensible via `Storage` interface)
 - **Key prefixing** for namespace isolation (`withPrefix()` returns a new instance — no mutation)
 - **Expired item cleanup** via `purgeExpired()`
 - **Comprehensive error handling** with custom exceptions
@@ -57,7 +57,7 @@ use WebFiori\Cache\FileStorage;
 use WebFiori\Cache\KeyManager;
 
 // Set up encryption key (recommended for production)
-$_ENV['CACHE_ENCRYPTION_KEY'] = KeyManager::generateKey();
+$_ENV['CACHE_KEY'] = KeyManager::generateKey();
 
 // Create a cache instance
 $cache = new Cache(new FileStorage('/path/to/cache'));
@@ -148,11 +148,11 @@ CacheFacade::withPrefix('users_')->set('count', 100, 60);
 
 ### Security & Encryption
 
-All cached data is encrypted by default using AES-256-CBC. Configure via environment variables or programmatically:
+Cached data is encrypted using AES-256-CBC when an encryption key is available. If no key is set, data is stored unencrypted. Configure via environment variables or programmatically:
 
 ```bash
 # 64-character hexadecimal encryption key (required for encryption)
-CACHE_ENCRYPTION_KEY=your64characterhexadecimalencryptionkeyhere1234567890abcdef
+CACHE_KEY=your64characterhexadecimalencryptionkeyhere1234567890abcdef
 
 # Optional settings
 CACHE_ENCRYPTION_ENABLED=true
@@ -171,9 +171,31 @@ KeyManager::setEncryptionKey($key);
 
 > See [Encryption Key Management](examples/advanced/03-encryption-key-management/), [Security Config](examples/advanced/04-security-config/), and [Encrypt/Decrypt Round-Trip](examples/advanced/06-encrypt-decrypt-roundtrip/).
 
+### Redis Storage
+
+A built-in Redis backend is available via `RedisStorage`. It requires the `ext-redis` PHP extension and a connected `\Redis` instance:
+
+```php
+use WebFiori\Cache\Cache;
+use WebFiori\Cache\RedisStorage;
+
+$redis = new Redis();
+$redis->connect('127.0.0.1', 6379);
+
+$storage = new RedisStorage($redis, 'wf_cache:');
+$cache = new Cache($storage);
+
+$cache->set('key', 'value', 3600);
+echo $cache->get('key'); // value
+```
+
+Redis handles TTL natively, so expired items are removed automatically — no need for `purgeExpired()`.
+
+> See [Redis Storage](examples/advanced/12-redis-storage/) for a full example.
+
 ### Custom Storage Drivers
 
-Implement the `Storage` interface to create custom backends (e.g., Redis, Memcached, database):
+Implement the `Storage` interface to create custom backends (e.g., Memcached, database):
 
 ```php
 use WebFiori\Cache\Storage;
@@ -320,6 +342,7 @@ The [examples/](examples/) directory contains 23 self-contained, runnable sample
 | 09 | [File Permissions](examples/advanced/09-file-permissions/) | Default and custom permissions |
 | 10 | [Error Handling](examples/advanced/10-error-handling/) | All exception types |
 | 11 | [Factory and DI](examples/advanced/11-factory-and-di/) | Constructor-based DI |
+| 12 | [Redis Storage](examples/advanced/12-redis-storage/) | Redis backend driver |
 
 Run any example:
 

--- a/WebFiori/Cache/Cache.php
+++ b/WebFiori/Cache/Cache.php
@@ -270,21 +270,15 @@ class Cache {
      * @throws CacheStorageException If storage fails.
      */
     private function storeItem(string $key, $data, int $ttl): void {
-        $secretKey = '';
-        try {
-            $secretKey = KeyManager::getEncryptionKey();
-        } catch (CacheException $e) {
-            $item = new Item($key, $data, $ttl, '');
+        $secretKey = KeyManager::getEncryptionKey();
+        $item = new Item($key, $data, $ttl, $secretKey ?? '');
+
+        if ($secretKey === null) {
             $config = new SecurityConfig();
             $config->setEncryptionEnabled(false);
             $item->setSecurityConfig($config);
-            $item->setPrefix($this->prefix);
-            $this->driver->store($item);
-
-            return;
         }
 
-        $item = new Item($key, $data, $ttl, $secretKey);
         $item->setPrefix($this->prefix);
         $this->driver->store($item);
     }

--- a/WebFiori/Cache/FileStorage.php
+++ b/WebFiori/Cache/FileStorage.php
@@ -181,18 +181,12 @@ class FileStorage implements Storage {
             return null;
         }
 
-        // Use KeyManager for encryption key if not provided, but handle gracefully if not available
-        $secretKey = '';
-        $encryptionEnabled = true;
-        try {
-            $secretKey = KeyManager::getEncryptionKey();
-        } catch (CacheException $e) {
-            // If no key available, assume encryption is disabled
-            $encryptionEnabled = false;
-        }
+        // Use KeyManager for encryption key
+        $secretKey = KeyManager::getEncryptionKey();
+        $encryptionEnabled = $secretKey !== null;
 
         // Create item with the stored encrypted/serialized data
-        $item = new Item($key, $this->data['data'], $this->data['ttl'], $secretKey);
+        $item = new Item($key, $this->data['data'], $this->data['ttl'], $secretKey ?? '');
         $item->setCreatedAt($this->data['created_at']);
         $item->setPrefix($prefix ?? '');
 

--- a/WebFiori/Cache/Item.php
+++ b/WebFiori/Cache/Item.php
@@ -376,13 +376,13 @@ class Item {
         }
 
         // Fall back to KeyManager
-        try {
-            $encKey = KeyManager::getEncryptionKey();
+        $encKey = KeyManager::getEncryptionKey();
 
+        if ($encKey !== null) {
             return hex2bin($encKey);
-        } catch (Exception $e) {
-            throw new CacheException('No valid encryption key available: '.$e->getMessage());
         }
+
+        throw new CacheException('No valid encryption key available. Set CACHE_KEY environment variable with a 64-character hexadecimal key.');
     }
 
     /**

--- a/WebFiori/Cache/KeyManager.php
+++ b/WebFiori/Cache/KeyManager.php
@@ -11,7 +11,6 @@
  */
 namespace WebFiori\Cache;
 
-use WebFiori\Cache\Exceptions\CacheException;
 use WebFiori\Cache\Exceptions\InvalidCacheKeyException;
 
 /**
@@ -39,10 +38,9 @@ class KeyManager {
     /**
      * Gets the encryption key for cache operations.
      * 
-     * @return string A valid 64-character hexadecimal encryption key
-     * @throws CacheException If no valid encryption key is available
+     * @return string|null A valid 64-character hexadecimal encryption key, or null if not available
      */
-    public static function getEncryptionKey(): string {
+    public static function getEncryptionKey(): ?string {
         if (self::$key === null) {
             self::$key = self::loadKey();
         }
@@ -76,17 +74,21 @@ class KeyManager {
     /**
      * Loads encryption key from environment variables only.
      * 
-     * @return string A valid encryption key
-     * @throws CacheException If no valid key can be loaded
+     * @return string|null A valid encryption key or null if not available
      */
-    private static function loadKey(): string {
-        // Load from environment variable only
-        $key = $_ENV['CACHE_ENCRYPTION_KEY'] ?? getenv('CACHE_ENCRYPTION_KEY');
+    private static function loadKey(): ?string {
+        // Load from environment variable
+        $key = $_ENV['CACHE_KEY'] ?? getenv('CACHE_KEY');
+
+        if (!$key) {
+            // Fallback to legacy env var for backward compatibility
+            $key = $_ENV['CACHE_ENCRYPTION_KEY'] ?? getenv('CACHE_ENCRYPTION_KEY');
+        }
 
         if ($key && self::isValidKey($key)) {
             return $key;
         }
 
-        throw new CacheException('No valid encryption key found. Please set CACHE_ENCRYPTION_KEY environment variable with a 64-character hexadecimal key.');
+        return null;
     }
 }

--- a/WebFiori/Cache/RedisStorage.php
+++ b/WebFiori/Cache/RedisStorage.php
@@ -1,0 +1,211 @@
+<?php
+
+/**
+ * This file is licensed under MIT License.
+ *
+ * Copyright (c) 2024 WebFiori Framework
+ *
+ * For more information on the license, please visit:
+ * https://github.com/WebFiori/.github/blob/main/LICENSE
+ *
+ */
+namespace WebFiori\Cache;
+
+use WebFiori\Cache\Exceptions\CacheException;
+use WebFiori\Cache\Exceptions\CacheStorageException;
+
+/**
+ * Redis based cache storage engine.
+ */
+class RedisStorage implements Storage {
+    private \Redis $redis;
+    private string $redisPrefix;
+
+    /**
+     * Creates new instance of the class.
+     *
+     * @param \Redis $redis A connected Redis instance.
+     * @param string $redisPrefix A prefix applied to all Redis keys to avoid
+     * collisions with other applications sharing the same Redis instance.
+     */
+    public function __construct(\Redis $redis, string $redisPrefix = 'wf_cache:') {
+        $this->redis = $redis;
+        $this->redisPrefix = $redisPrefix;
+    }
+
+    /**
+     * Removes an item from the cache.
+     *
+     * @param string $key The key of the item.
+     */
+    public function delete(string $key) {
+        $this->redis->del($this->redisPrefix.md5($key));
+    }
+
+    /**
+     * Removes all cached items.
+     *
+     * @param string|null $prefix An optional prefix. If provided, only items
+     * with that prefix are deleted.
+     */
+    public function flush(?string $prefix) {
+        $pattern = $this->redisPrefix.($prefix ?? '').'*';
+        $iterator = null;
+
+        while (($keys = $this->redis->scan($iterator, $pattern, 100)) !== false) {
+            if (!empty($keys)) {
+                $this->redis->del($keys);
+            }
+        }
+    }
+
+    /**
+     * Returns the Redis instance used by this storage.
+     *
+     * @return \Redis
+     */
+    public function getRedis(): \Redis {
+        return $this->redis;
+    }
+
+    /**
+     * Returns the Redis key prefix.
+     *
+     * @return string
+     */
+    public function getRedisPrefix(): string {
+        return $this->redisPrefix;
+    }
+
+    /**
+     * Checks if an item exist in the cache.
+     *
+     * @param string $key The value of item key.
+     * @param string|null $prefix Optional prefix.
+     *
+     * @return bool Returns true if given key exist in the cache.
+     */
+    public function has(string $key, ?string $prefix): bool {
+        return $this->redis->exists($this->buildRedisKey($key, $prefix)) > 0;
+    }
+
+    /**
+     * Redis handles expiry natively, so this is a no-op.
+     *
+     * @return int Always returns 0.
+     */
+    public function purgeExpired(): int {
+        return 0;
+    }
+
+    /**
+     * Reads and returns the data stored in cache item given its key.
+     *
+     * @param string $key The key of the item.
+     * @param string|null $prefix Optional prefix.
+     *
+     * @return mixed|null If cache item is not expired, its data is returned.
+     * Otherwise, null is returned.
+     */
+    public function read(string $key, ?string $prefix) {
+        $item = $this->readItem($key, $prefix);
+
+        if ($item !== null) {
+            try {
+                return $item->getDataDecrypted();
+            } catch (CacheException $e) {
+                $this->delete(($prefix ?? '').$key);
+
+                return null;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Reads cache item as an object given its key.
+     *
+     * @param string $key The unique identifier of the item.
+     * @param string|null $prefix Optional prefix.
+     *
+     * @return Item|null If cache item exist, an object of type 'Item' is returned.
+     * Otherwise, null is returned.
+     */
+    public function readItem(string $key, ?string $prefix) {
+        $raw = $this->redis->get($this->buildRedisKey($key, $prefix));
+
+        if ($raw === false) {
+            return null;
+        }
+
+        $data = json_decode($raw, true);
+
+        if ($data === null) {
+            return null;
+        }
+
+        $secretKey = KeyManager::getEncryptionKey();
+        $encryptionEnabled = $secretKey !== null;
+
+        $item = new Item($key, $data['data'], $data['ttl'], $secretKey ?? '');
+        $item->setCreatedAt($data['created_at']);
+        $item->setPrefix($prefix ?? '');
+
+        $wasEncrypted = $data['encrypted'] ?? true;
+
+        if (!$wasEncrypted || !$encryptionEnabled) {
+            $config = new SecurityConfig();
+            $config->setEncryptionEnabled(false);
+            $item->setSecurityConfig($config);
+        }
+
+        $item->setDataIsEncrypted($wasEncrypted);
+        $item->setDataFromStorage(true);
+
+        return $item;
+    }
+
+    /**
+     * Store an item into the cache.
+     *
+     * @param Item $item An item that will be added to the cache.
+     * @throws CacheStorageException If storage fails.
+     */
+    public function store(Item $item) {
+        if ($item->getTTL() <= 0) {
+            return;
+        }
+
+        $redisKey = $this->buildRedisKey($item->getKey(), $item->getPrefix() ?: null);
+        $payload = json_encode([
+            'data' => $item->getDataEncrypted(),
+            'created_at' => time(),
+            'ttl' => $item->getTTL(),
+            'expires' => $item->getExpiryTime(),
+            'key' => $item->getKey(),
+            'encrypted' => $item->getSecurityConfig()->isEncryptionEnabled()
+        ]);
+
+        if ($payload === false) {
+            throw new CacheStorageException("Failed to encode cache data to JSON for key: {$item->getKey()}");
+        }
+
+        $result = $this->redis->setex($redisKey, $item->getTTL(), $payload);
+
+        if ($result === false) {
+            throw new CacheStorageException("Failed to store cache item in Redis for key: {$item->getKey()}");
+        }
+    }
+
+    /**
+     * Builds the full Redis key from cache key and prefix.
+     *
+     * @param string $key The cache key.
+     * @param string|null $prefix Optional prefix.
+     * @return string The full Redis key.
+     */
+    private function buildRedisKey(string $key, ?string $prefix): string {
+        return $this->redisPrefix.($prefix ?? '').md5($key);
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,9 @@
         "friendsofphp/php-cs-fixer": "^3.0",
         "phpunit/phpunit": "^10.0"
     },
+    "suggest": {
+        "ext-redis": "Required for RedisStorage driver"
+    },
     "scripts": {
         "test": "vendor/bin/phpunit -c tests/phpunit.xml",
         "test10": "vendor/bin/phpunit -c tests/phpunit10.xml",

--- a/examples/README.md
+++ b/examples/README.md
@@ -48,3 +48,4 @@ php examples/basic/01-set-and-get/index.php
 | 09 | [File Permissions](advanced/09-file-permissions/) | Default and custom file/directory permissions |
 | 10 | [Error Handling](advanced/10-error-handling/) | Exception types and when they are thrown |
 | 11 | [Factory and DI](advanced/11-factory-and-di/) | Create cache instances for dependency injection |
+| 12 | [Redis Storage](advanced/12-redis-storage/) | Redis backend driver |

--- a/examples/advanced/01-prefix-isolation/index.php
+++ b/examples/advanced/01-prefix-isolation/index.php
@@ -6,7 +6,7 @@ use WebFiori\Cache\Cache;
 use WebFiori\Cache\FileStorage;
 use WebFiori\Cache\KeyManager;
 
-$_ENV['CACHE_ENCRYPTION_KEY'] = KeyManager::generateKey();
+$_ENV['CACHE_KEY'] = KeyManager::generateKey();
 
 $cache = new Cache(new FileStorage(__DIR__.'/cache'));
 

--- a/examples/advanced/02-prefix-flush/index.php
+++ b/examples/advanced/02-prefix-flush/index.php
@@ -6,7 +6,7 @@ use WebFiori\Cache\Cache;
 use WebFiori\Cache\FileStorage;
 use WebFiori\Cache\KeyManager;
 
-$_ENV['CACHE_ENCRYPTION_KEY'] = KeyManager::generateKey();
+$_ENV['CACHE_KEY'] = KeyManager::generateKey();
 
 $cache = new Cache(new FileStorage(__DIR__.'/cache'));
 $app1 = $cache->withPrefix('app1_');

--- a/examples/advanced/03-encryption-key-management/index.php
+++ b/examples/advanced/03-encryption-key-management/index.php
@@ -2,7 +2,6 @@
 
 require_once __DIR__.'/../../../vendor/autoload.php';
 
-use WebFiori\Cache\Exceptions\CacheException;
 use WebFiori\Cache\Exceptions\InvalidCacheKeyException;
 use WebFiori\Cache\KeyManager;
 
@@ -18,8 +17,8 @@ echo "Retrieved key: ".KeyManager::getEncryptionKey()."\n\n";
 
 // 3. Set via environment variable
 KeyManager::clearCache();
-$_ENV['CACHE_ENCRYPTION_KEY'] = $key;
-echo "Key set via \$_ENV['CACHE_ENCRYPTION_KEY'].\n";
+$_ENV['CACHE_KEY'] = $key;
+echo "Key set via \$_ENV['CACHE_KEY'].\n";
 echo "Retrieved key: ".KeyManager::getEncryptionKey()."\n\n";
 
 // 4. Invalid key is rejected
@@ -29,11 +28,8 @@ try {
     echo "Invalid key rejected: ".$e->getMessage()."\n\n";
 }
 
-// 5. Missing key throws exception
+// 5. Missing key returns null
 KeyManager::clearCache();
-unset($_ENV['CACHE_ENCRYPTION_KEY']);
-try {
-    KeyManager::getEncryptionKey();
-} catch (CacheException $e) {
-    echo "Missing key error: ".$e->getMessage()."\n";
-}
+unset($_ENV['CACHE_KEY']);
+$result = KeyManager::getEncryptionKey();
+echo "Missing key result: ".($result === null ? 'null (encryption disabled)' : $result)."\n";

--- a/examples/advanced/06-encrypt-decrypt-roundtrip/index.php
+++ b/examples/advanced/06-encrypt-decrypt-roundtrip/index.php
@@ -5,7 +5,7 @@ require_once __DIR__.'/../../../vendor/autoload.php';
 use WebFiori\Cache\Item;
 use WebFiori\Cache\KeyManager;
 
-$_ENV['CACHE_ENCRYPTION_KEY'] = KeyManager::generateKey();
+$_ENV['CACHE_KEY'] = KeyManager::generateKey();
 
 $secret = KeyManager::getEncryptionKey();
 $original = 'Sensitive payment info: card ending 1234';

--- a/examples/advanced/07-custom-storage-driver/index.php
+++ b/examples/advanced/07-custom-storage-driver/index.php
@@ -7,7 +7,7 @@ use WebFiori\Cache\Item;
 use WebFiori\Cache\KeyManager;
 use WebFiori\Cache\Storage;
 
-$_ENV['CACHE_ENCRYPTION_KEY'] = KeyManager::generateKey();
+$_ENV['CACHE_KEY'] = KeyManager::generateKey();
 
 /**
  * A simple in-memory storage driver.

--- a/examples/advanced/08-file-storage-custom-path/index.php
+++ b/examples/advanced/08-file-storage-custom-path/index.php
@@ -6,7 +6,7 @@ use WebFiori\Cache\Cache;
 use WebFiori\Cache\FileStorage;
 use WebFiori\Cache\KeyManager;
 
-$_ENV['CACHE_ENCRYPTION_KEY'] = KeyManager::generateKey();
+$_ENV['CACHE_KEY'] = KeyManager::generateKey();
 
 $customPath = __DIR__.'/my_cache';
 

--- a/examples/advanced/09-file-permissions/index.php
+++ b/examples/advanced/09-file-permissions/index.php
@@ -7,7 +7,7 @@ use WebFiori\Cache\Item;
 use WebFiori\Cache\KeyManager;
 use WebFiori\Cache\SecurityConfig;
 
-$_ENV['CACHE_ENCRYPTION_KEY'] = KeyManager::generateKey();
+$_ENV['CACHE_KEY'] = KeyManager::generateKey();
 
 $cacheDir = __DIR__.'/perm_cache';
 

--- a/examples/advanced/10-error-handling/index.php
+++ b/examples/advanced/10-error-handling/index.php
@@ -3,13 +3,12 @@
 require_once __DIR__.'/../../../vendor/autoload.php';
 
 use WebFiori\Cache\Cache;
-use WebFiori\Cache\Exceptions\CacheException;
 use WebFiori\Cache\Exceptions\CacheStorageException;
 use WebFiori\Cache\Exceptions\InvalidCacheKeyException;
 use WebFiori\Cache\FileStorage;
 use WebFiori\Cache\KeyManager;
 
-$_ENV['CACHE_ENCRYPTION_KEY'] = KeyManager::generateKey();
+$_ENV['CACHE_KEY'] = KeyManager::generateKey();
 
 $cache = new Cache(new FileStorage(__DIR__.'/cache'));
 
@@ -57,15 +56,12 @@ try {
     unlink($tempFile);
 }
 
-// 6. Missing encryption key when encryption is enabled
+// 6. Missing encryption key returns null (encryption disabled gracefully)
 echo "6. Missing encryption key:\n";
 KeyManager::clearCache();
-unset($_ENV['CACHE_ENCRYPTION_KEY']);
-try {
-    KeyManager::getEncryptionKey();
-} catch (CacheException $e) {
-    echo "   ".$e->getMessage()."\n";
-}
+unset($_ENV['CACHE_KEY']);
+$key = KeyManager::getEncryptionKey();
+echo "   Key is ".($key === null ? 'null — encryption disabled' : $key)."\n";
 
 $cache->flush();
 

--- a/examples/advanced/11-factory-and-di/index.php
+++ b/examples/advanced/11-factory-and-di/index.php
@@ -6,7 +6,7 @@ use WebFiori\Cache\Cache;
 use WebFiori\Cache\FileStorage;
 use WebFiori\Cache\KeyManager;
 
-$_ENV['CACHE_ENCRYPTION_KEY'] = KeyManager::generateKey();
+$_ENV['CACHE_KEY'] = KeyManager::generateKey();
 
 $cacheDir = __DIR__.'/factory_cache';
 

--- a/examples/advanced/12-redis-storage/README.md
+++ b/examples/advanced/12-redis-storage/README.md
@@ -1,0 +1,22 @@
+# Redis Storage Driver
+
+Demonstrates using Redis as the cache backend via `RedisStorage`.
+
+## Prerequisites
+
+- PHP `ext-redis` extension installed
+- Redis server running on `127.0.0.1:6379`
+
+## What it demonstrates
+
+- Creating a `RedisStorage` with a connected `\Redis` instance
+- Basic `set()` / `get()` operations backed by Redis
+- Prefix isolation with `withPrefix()`
+- Generator callbacks for cache-miss population
+- Redis native TTL handling (no manual expiry cleanup needed)
+
+## Run
+
+```bash
+php examples/advanced/12-redis-storage/index.php
+```

--- a/examples/advanced/12-redis-storage/index.php
+++ b/examples/advanced/12-redis-storage/index.php
@@ -1,0 +1,43 @@
+<?php
+
+require_once __DIR__.'/../../../vendor/autoload.php';
+
+use WebFiori\Cache\Cache;
+use WebFiori\Cache\KeyManager;
+use WebFiori\Cache\RedisStorage;
+
+// Optional: set encryption key
+$_ENV['CACHE_KEY'] = KeyManager::generateKey();
+
+// Connect to Redis
+$redis = new Redis();
+$redis->connect('127.0.0.1', 6379);
+
+// Create cache with Redis backend
+$storage = new RedisStorage($redis, 'wf_cache:');
+$cache = new Cache($storage);
+
+// Basic set and get
+$cache->set('greeting', 'Hello from Redis!', 60);
+echo $cache->get('greeting')."\n"; // Hello from Redis!
+
+// Prefix isolation
+$users = $cache->withPrefix('users_');
+$orders = $cache->withPrefix('orders_');
+
+$users->set('count', 42, 60);
+$orders->set('count', 100, 60);
+
+echo "Users: ".$users->get('count')."\n";   // 42
+echo "Orders: ".$orders->get('count')."\n"; // 100
+
+// Generator callback
+$data = $cache->get('computed', function () {
+    return ['result' => 'expensive computation'];
+}, 120);
+
+echo "Computed: ".print_r($data, true)."\n";
+
+// Cleanup
+$cache->flush();
+echo "Done.\n";

--- a/examples/basic/01-set-and-get/index.php
+++ b/examples/basic/01-set-and-get/index.php
@@ -6,7 +6,7 @@ use WebFiori\Cache\Cache;
 use WebFiori\Cache\FileStorage;
 use WebFiori\Cache\KeyManager;
 
-$_ENV['CACHE_ENCRYPTION_KEY'] = KeyManager::generateKey();
+$_ENV['CACHE_KEY'] = KeyManager::generateKey();
 
 $cache = new Cache(new FileStorage(__DIR__.'/cache'));
 

--- a/examples/basic/02-get-with-generator/index.php
+++ b/examples/basic/02-get-with-generator/index.php
@@ -6,7 +6,7 @@ use WebFiori\Cache\Cache;
 use WebFiori\Cache\FileStorage;
 use WebFiori\Cache\KeyManager;
 
-$_ENV['CACHE_ENCRYPTION_KEY'] = KeyManager::generateKey();
+$_ENV['CACHE_KEY'] = KeyManager::generateKey();
 
 $cache = new Cache(new FileStorage(__DIR__.'/cache'));
 

--- a/examples/basic/03-generator-with-params/index.php
+++ b/examples/basic/03-generator-with-params/index.php
@@ -6,7 +6,7 @@ use WebFiori\Cache\Cache;
 use WebFiori\Cache\FileStorage;
 use WebFiori\Cache\KeyManager;
 
-$_ENV['CACHE_ENCRYPTION_KEY'] = KeyManager::generateKey();
+$_ENV['CACHE_KEY'] = KeyManager::generateKey();
 
 $cache = new Cache(new FileStorage(__DIR__.'/cache'));
 

--- a/examples/basic/04-check-existence/index.php
+++ b/examples/basic/04-check-existence/index.php
@@ -6,7 +6,7 @@ use WebFiori\Cache\Cache;
 use WebFiori\Cache\FileStorage;
 use WebFiori\Cache\KeyManager;
 
-$_ENV['CACHE_ENCRYPTION_KEY'] = KeyManager::generateKey();
+$_ENV['CACHE_KEY'] = KeyManager::generateKey();
 
 $cache = new Cache(new FileStorage(__DIR__.'/cache'));
 

--- a/examples/basic/05-delete-item/index.php
+++ b/examples/basic/05-delete-item/index.php
@@ -6,7 +6,7 @@ use WebFiori\Cache\Cache;
 use WebFiori\Cache\FileStorage;
 use WebFiori\Cache\KeyManager;
 
-$_ENV['CACHE_ENCRYPTION_KEY'] = KeyManager::generateKey();
+$_ENV['CACHE_KEY'] = KeyManager::generateKey();
 
 $cache = new Cache(new FileStorage(__DIR__.'/cache'));
 

--- a/examples/basic/06-flush-cache/index.php
+++ b/examples/basic/06-flush-cache/index.php
@@ -6,7 +6,7 @@ use WebFiori\Cache\Cache;
 use WebFiori\Cache\FileStorage;
 use WebFiori\Cache\KeyManager;
 
-$_ENV['CACHE_ENCRYPTION_KEY'] = KeyManager::generateKey();
+$_ENV['CACHE_KEY'] = KeyManager::generateKey();
 
 $cache = new Cache(new FileStorage(__DIR__.'/cache'));
 

--- a/examples/basic/07-update-ttl/index.php
+++ b/examples/basic/07-update-ttl/index.php
@@ -6,7 +6,7 @@ use WebFiori\Cache\Cache;
 use WebFiori\Cache\FileStorage;
 use WebFiori\Cache\KeyManager;
 
-$_ENV['CACHE_ENCRYPTION_KEY'] = KeyManager::generateKey();
+$_ENV['CACHE_KEY'] = KeyManager::generateKey();
 
 $cache = new Cache(new FileStorage(__DIR__.'/cache'));
 

--- a/examples/basic/08-override-behavior/index.php
+++ b/examples/basic/08-override-behavior/index.php
@@ -6,7 +6,7 @@ use WebFiori\Cache\Cache;
 use WebFiori\Cache\FileStorage;
 use WebFiori\Cache\KeyManager;
 
-$_ENV['CACHE_ENCRYPTION_KEY'] = KeyManager::generateKey();
+$_ENV['CACHE_KEY'] = KeyManager::generateKey();
 
 $cache = new Cache(new FileStorage(__DIR__.'/cache'));
 

--- a/examples/basic/09-ttl-expiration/index.php
+++ b/examples/basic/09-ttl-expiration/index.php
@@ -6,7 +6,7 @@ use WebFiori\Cache\Cache;
 use WebFiori\Cache\FileStorage;
 use WebFiori\Cache\KeyManager;
 
-$_ENV['CACHE_ENCRYPTION_KEY'] = KeyManager::generateKey();
+$_ENV['CACHE_KEY'] = KeyManager::generateKey();
 
 $cache = new Cache(new FileStorage(__DIR__.'/cache'));
 

--- a/examples/basic/10-enable-disable/index.php
+++ b/examples/basic/10-enable-disable/index.php
@@ -6,7 +6,7 @@ use WebFiori\Cache\Cache;
 use WebFiori\Cache\FileStorage;
 use WebFiori\Cache\KeyManager;
 
-$_ENV['CACHE_ENCRYPTION_KEY'] = KeyManager::generateKey();
+$_ENV['CACHE_KEY'] = KeyManager::generateKey();
 
 $cache = new Cache(new FileStorage(__DIR__.'/cache'));
 

--- a/examples/basic/11-item-inspection/index.php
+++ b/examples/basic/11-item-inspection/index.php
@@ -6,7 +6,7 @@ use WebFiori\Cache\Cache;
 use WebFiori\Cache\FileStorage;
 use WebFiori\Cache\KeyManager;
 
-$_ENV['CACHE_ENCRYPTION_KEY'] = KeyManager::generateKey();
+$_ENV['CACHE_KEY'] = KeyManager::generateKey();
 
 $cache = new Cache(new FileStorage(__DIR__.'/cache'));
 

--- a/examples/basic/12-data-types/index.php
+++ b/examples/basic/12-data-types/index.php
@@ -6,7 +6,7 @@ use WebFiori\Cache\Cache;
 use WebFiori\Cache\FileStorage;
 use WebFiori\Cache\KeyManager;
 
-$_ENV['CACHE_ENCRYPTION_KEY'] = KeyManager::generateKey();
+$_ENV['CACHE_KEY'] = KeyManager::generateKey();
 
 $cache = new Cache(new FileStorage(__DIR__.'/cache'));
 

--- a/tests/WebFiori/Test/Cache/CacheTest.php
+++ b/tests/WebFiori/Test/Cache/CacheTest.php
@@ -16,7 +16,7 @@ class CacheTest extends TestCase {
 
     protected function setUp(): void {
         $testKey = KeyManager::generateKey();
-        $_ENV['CACHE_ENCRYPTION_KEY'] = $testKey;
+        $_ENV['CACHE_KEY'] = $testKey;
         KeyManager::clearCache();
 
         $this->cache = new Cache(new FileStorage(__DIR__ . '/test_cache'));
@@ -26,7 +26,7 @@ class CacheTest extends TestCase {
     protected function tearDown(): void {
         KeyManager::clearCache();
         $this->cache->flush();
-        unset($_ENV['CACHE_ENCRYPTION_KEY']);
+        unset($_ENV['CACHE_KEY']);
     }
 
     /**
@@ -713,7 +713,7 @@ class CacheTest extends TestCase {
      */
     public function testCacheFacadeBasicOperations() {
         $testKey = KeyManager::generateKey();
-        $_ENV['CACHE_ENCRYPTION_KEY'] = $testKey;
+        $_ENV['CACHE_KEY'] = $testKey;
         KeyManager::clearCache();
 
         \WebFiori\Cache\CacheFacade::reset();

--- a/tests/WebFiori/Test/Cache/FileStorageTest.php
+++ b/tests/WebFiori/Test/Cache/FileStorageTest.php
@@ -18,7 +18,7 @@ class FileStorageTest extends TestCase {
     protected function setUp(): void {
         // Set up a test encryption key for consistent testing
         $testKey = KeyManager::generateKey();
-        $_ENV['CACHE_ENCRYPTION_KEY'] = $testKey;
+        $_ENV['CACHE_KEY'] = $testKey;
         KeyManager::clearCache();
         
         $this->testDir = __DIR__ . '/test_file_storage_' . uniqid();
@@ -37,7 +37,7 @@ class FileStorageTest extends TestCase {
         }
         
         KeyManager::clearCache();
-        unset($_ENV['CACHE_ENCRYPTION_KEY']);
+        unset($_ENV['CACHE_KEY']);
     }
     
     /**
@@ -397,8 +397,8 @@ class FileStorageTest extends TestCase {
      */
     public function testStorageWithoutEncryption() {
         // Clear encryption key to test without encryption
-        $originalKey = $_ENV['CACHE_ENCRYPTION_KEY'] ?? null;
-        unset($_ENV['CACHE_ENCRYPTION_KEY']);
+        $originalKey = $_ENV['CACHE_KEY'] ?? null;
+        unset($_ENV['CACHE_KEY']);
         KeyManager::clearCache();
         
         try {
@@ -419,7 +419,7 @@ class FileStorageTest extends TestCase {
         } finally {
             // Restore original key
             if ($originalKey !== null) {
-                $_ENV['CACHE_ENCRYPTION_KEY'] = $originalKey;
+                $_ENV['CACHE_KEY'] = $originalKey;
                 KeyManager::clearCache();
             }
         }

--- a/tests/WebFiori/Test/Cache/IntegrationTest.php
+++ b/tests/WebFiori/Test/Cache/IntegrationTest.php
@@ -20,7 +20,7 @@ class IntegrationTest extends TestCase {
 
     protected function setUp(): void {
         $testKey = KeyManager::generateKey();
-        $_ENV['CACHE_ENCRYPTION_KEY'] = $testKey;
+        $_ENV['CACHE_KEY'] = $testKey;
         KeyManager::clearCache();
 
         $this->cache = new Cache(new FileStorage(__DIR__ . '/test_integration_cache'));
@@ -30,7 +30,7 @@ class IntegrationTest extends TestCase {
     protected function tearDown(): void {
         KeyManager::clearCache();
         $this->cache->flush();
-        unset($_ENV['CACHE_ENCRYPTION_KEY']);
+        unset($_ENV['CACHE_KEY']);
     }
 
     /**

--- a/tests/WebFiori/Test/Cache/RedisStorageTest.php
+++ b/tests/WebFiori/Test/Cache/RedisStorageTest.php
@@ -1,0 +1,219 @@
+<?php
+
+namespace WebFiori\Test\Cache;
+
+use PHPUnit\Framework\TestCase;
+use WebFiori\Cache\Cache;
+use WebFiori\Cache\Item;
+use WebFiori\Cache\KeyManager;
+use WebFiori\Cache\RedisStorage;
+use WebFiori\Cache\SecurityConfig;
+
+/**
+ * @group redis
+ */
+class RedisStorageTest extends TestCase {
+    private static \Redis $redis;
+    private static string $prefix = 'wf_test:';
+
+    public static function setUpBeforeClass(): void {
+        if (!extension_loaded('redis')) {
+            self::markTestSkipped('ext-redis is not available.');
+        }
+
+        self::$redis = new \Redis();
+
+        if (!@self::$redis->connect('127.0.0.1', 6379, 2.0)) {
+            self::markTestSkipped('Cannot connect to Redis at 127.0.0.1:6379.');
+        }
+    }
+
+    protected function setUp(): void {
+        $testKey = KeyManager::generateKey();
+        $_ENV['CACHE_KEY'] = $testKey;
+        KeyManager::clearCache();
+
+        // Flush test keys
+        $iterator = null;
+
+        while (($keys = self::$redis->scan($iterator, self::$prefix.'*', 100)) !== false) {
+            if (!empty($keys)) {
+                self::$redis->del($keys);
+            }
+        }
+    }
+
+    protected function tearDown(): void {
+        unset($_ENV['CACHE_KEY']);
+        KeyManager::clearCache();
+    }
+
+    public function testStoreAndRead(): void {
+        $storage = new RedisStorage(self::$redis, self::$prefix);
+        $cache = new Cache($storage);
+
+        $cache->set('hello', 'world', 60);
+        $this->assertEquals('world', $cache->get('hello'));
+    }
+
+    public function testStoreAndReadWithoutEncryption(): void {
+        unset($_ENV['CACHE_KEY']);
+        KeyManager::clearCache();
+
+        $storage = new RedisStorage(self::$redis, self::$prefix);
+        $cache = new Cache($storage);
+
+        $cache->set('plain', 'text_value', 60);
+        $this->assertEquals('text_value', $cache->get('plain'));
+    }
+
+    public function testHas(): void {
+        $storage = new RedisStorage(self::$redis, self::$prefix);
+        $cache = new Cache($storage);
+
+        $this->assertFalse($cache->has('missing'));
+        $cache->set('exists', 'data', 60);
+        $this->assertTrue($cache->has('exists'));
+    }
+
+    public function testDelete(): void {
+        $storage = new RedisStorage(self::$redis, self::$prefix);
+        $cache = new Cache($storage);
+
+        $cache->set('to_delete', 'value', 60);
+        $this->assertTrue($cache->has('to_delete'));
+
+        $cache->delete('to_delete');
+        $this->assertFalse($cache->has('to_delete'));
+    }
+
+    public function testFlush(): void {
+        $storage = new RedisStorage(self::$redis, self::$prefix);
+        $cache = new Cache($storage);
+
+        $cache->set('a', '1', 60);
+        $cache->set('b', '2', 60);
+        $cache->flush();
+
+        $this->assertFalse($cache->has('a'));
+        $this->assertFalse($cache->has('b'));
+    }
+
+    public function testFlushWithPrefix(): void {
+        $storage = new RedisStorage(self::$redis, self::$prefix);
+        $cache = new Cache($storage);
+
+        $users = $cache->withPrefix('users_');
+        $orders = $cache->withPrefix('orders_');
+
+        $users->set('count', 10, 60);
+        $orders->set('count', 20, 60);
+
+        $users->flush();
+
+        $this->assertFalse($users->has('count'));
+        $this->assertTrue($orders->has('count'));
+    }
+
+    public function testTTLExpiration(): void {
+        $storage = new RedisStorage(self::$redis, self::$prefix);
+        $cache = new Cache($storage);
+
+        $cache->set('short_lived', 'data', 1);
+        $this->assertTrue($cache->has('short_lived'));
+
+        sleep(2);
+        $this->assertFalse($cache->has('short_lived'));
+    }
+
+    public function testPurgeExpiredReturnsZero(): void {
+        $storage = new RedisStorage(self::$redis, self::$prefix);
+        $this->assertEquals(0, $storage->purgeExpired());
+    }
+
+    public function testGetWithGenerator(): void {
+        $storage = new RedisStorage(self::$redis, self::$prefix);
+        $cache = new Cache($storage);
+
+        $value = $cache->get('generated', function () {
+            return 'from_callback';
+        }, 60);
+
+        $this->assertEquals('from_callback', $value);
+        $this->assertEquals('from_callback', $cache->get('generated'));
+    }
+
+    public function testDataTypes(): void {
+        $storage = new RedisStorage(self::$redis, self::$prefix);
+        $cache = new Cache($storage);
+
+        // Array
+        $cache->set('arr', ['a' => 1, 'b' => 2], 60, true);
+        $this->assertEquals(['a' => 1, 'b' => 2], $cache->get('arr'));
+
+        // Integer
+        $cache->set('int', 42, 60, true);
+        $this->assertEquals(42, $cache->get('int'));
+
+        // Boolean
+        $cache->set('bool', true, 60, true);
+        $this->assertTrue($cache->get('bool'));
+
+        // Null
+        $cache->set('null_val', null, 60, true);
+        $this->assertNull($cache->get('null_val'));
+    }
+
+    public function testGetItem(): void {
+        $storage = new RedisStorage(self::$redis, self::$prefix);
+        $cache = new Cache($storage);
+
+        $cache->set('meta', 'info', 120);
+        $item = $cache->getItem('meta');
+
+        $this->assertInstanceOf(Item::class, $item);
+        $this->assertEquals('meta', $item->getKey());
+        $this->assertEquals(120, $item->getTTL());
+    }
+
+    public function testSetTTL(): void {
+        $storage = new RedisStorage(self::$redis, self::$prefix);
+        $cache = new Cache($storage);
+
+        $cache->set('ttl_test', 'value', 60);
+        $result = $cache->setTTL('ttl_test', 300);
+
+        $this->assertTrue($result);
+
+        $item = $cache->getItem('ttl_test');
+        $this->assertEquals(300, $item->getTTL());
+    }
+
+    public function testOverrideBehavior(): void {
+        $storage = new RedisStorage(self::$redis, self::$prefix);
+        $cache = new Cache($storage);
+
+        $cache->set('key', 'original', 60);
+        $this->assertFalse($cache->set('key', 'new', 60, false));
+        $this->assertEquals('original', $cache->get('key'));
+
+        $this->assertTrue($cache->set('key', 'new', 60, true));
+        $this->assertEquals('new', $cache->get('key'));
+    }
+
+    public function testGetRedisAndPrefix(): void {
+        $storage = new RedisStorage(self::$redis, self::$prefix);
+        $this->assertSame(self::$redis, $storage->getRedis());
+        $this->assertEquals(self::$prefix, $storage->getRedisPrefix());
+    }
+
+    public function testReadItemReturnsNullForMissing(): void {
+        $storage = new RedisStorage(self::$redis, self::$prefix);
+        $this->assertNull($storage->readItem('nonexistent', null));
+    }
+
+    public function testReadReturnsNullForMissing(): void {
+        $storage = new RedisStorage(self::$redis, self::$prefix);
+        $this->assertNull($storage->read('nonexistent', null));
+    }
+}

--- a/tests/WebFiori/Test/Cache/SecurityTest.php
+++ b/tests/WebFiori/Test/Cache/SecurityTest.php
@@ -20,7 +20,7 @@ class SecurityTest extends TestCase {
 
     protected function setUp(): void {
         $testKey = KeyManager::generateKey();
-        $_ENV['CACHE_ENCRYPTION_KEY'] = $testKey;
+        $_ENV['CACHE_KEY'] = $testKey;
         KeyManager::clearCache();
 
         $this->cache = new Cache(new FileStorage(__DIR__ . '/test_security_cache'));
@@ -85,21 +85,19 @@ class SecurityTest extends TestCase {
      */
     public function testKeyManagerRequiresEnvironmentVariable() {
         // Store current environment variable
-        $originalKey = $_ENV['CACHE_ENCRYPTION_KEY'] ?? null;
+        $originalKey = $_ENV['CACHE_KEY'] ?? null;
         
         try {
             // Clear any existing keys and environment variables
             KeyManager::clearCache();
-            unset($_ENV['CACHE_ENCRYPTION_KEY']);
+            unset($_ENV['CACHE_KEY']);
             
-            $this->expectException(CacheException::class);
-            $this->expectExceptionMessage('No valid encryption key found. Please set CACHE_ENCRYPTION_KEY environment variable');
-            
-            KeyManager::getEncryptionKey();
+            $result = KeyManager::getEncryptionKey();
+            $this->assertNull($result);
         } finally {
             // Restore environment variable
             if ($originalKey !== null) {
-                $_ENV['CACHE_ENCRYPTION_KEY'] = $originalKey;
+                $_ENV['CACHE_KEY'] = $originalKey;
                 KeyManager::clearCache(); // Force reload
             }
         }
@@ -201,15 +199,15 @@ class SecurityTest extends TestCase {
      */
     public function testItemFailsWithoutValidKeyWhenEncryptionEnabled() {
         // Store current environment variable
-        $originalKey = $_ENV['CACHE_ENCRYPTION_KEY'] ?? null;
+        $originalKey = $_ENV['CACHE_KEY'] ?? null;
         
         try {
             // Clear any existing keys and environment variables
             KeyManager::clearCache();
-            unset($_ENV['CACHE_ENCRYPTION_KEY']);
+            unset($_ENV['CACHE_KEY']);
             
             $this->expectException(CacheException::class);
-            $this->expectExceptionMessage('No valid encryption key available');
+            $this->expectExceptionMessage('No valid encryption key available. Set CACHE_KEY environment variable');
             
             $item = new Item('test', 'data', 60, '');
             // This should fail because no key is available and encryption is enabled
@@ -217,7 +215,7 @@ class SecurityTest extends TestCase {
         } finally {
             // Restore environment variable
             if ($originalKey !== null) {
-                $_ENV['CACHE_ENCRYPTION_KEY'] = $originalKey;
+                $_ENV['CACHE_KEY'] = $originalKey;
                 KeyManager::clearCache(); // Force reload
             }
         }
@@ -228,7 +226,7 @@ class SecurityTest extends TestCase {
      */
     public function testCacheUsesKeyManager() {
         $validKey = KeyManager::generateKey();
-        $_ENV['CACHE_ENCRYPTION_KEY'] = $validKey;
+        $_ENV['CACHE_KEY'] = $validKey;
         KeyManager::clearCache(); // Force reload from environment
         
         $testData = 'Test cache data';
@@ -299,7 +297,7 @@ class SecurityTest extends TestCase {
      */
     public function testEncryptionDecryptionRoundTrip() {
         $validKey = KeyManager::generateKey();
-        $_ENV['CACHE_ENCRYPTION_KEY'] = $validKey;
+        $_ENV['CACHE_KEY'] = $validKey;
         KeyManager::clearCache(); // Force reload from environment
         
         $complexData = [
@@ -320,7 +318,7 @@ class SecurityTest extends TestCase {
      */
     public function testKeyManagerEnvironmentVariable() {
         $validKey = KeyManager::generateKey();
-        $_ENV['CACHE_ENCRYPTION_KEY'] = $validKey;
+        $_ENV['CACHE_KEY'] = $validKey;
         
         KeyManager::clearCache();
         $retrievedKey = KeyManager::getEncryptionKey();
@@ -328,7 +326,7 @@ class SecurityTest extends TestCase {
         $this->assertEquals($validKey, $retrievedKey);
         
         // Clean up
-        unset($_ENV['CACHE_ENCRYPTION_KEY']);
+        unset($_ENV['CACHE_KEY']);
     }
     
     /**
@@ -731,7 +729,7 @@ class SecurityTest extends TestCase {
         KeyManager::clearCache();
         
         // After clearing cache, it should reload from environment
-        $envKey = $_ENV['CACHE_ENCRYPTION_KEY'];
+        $envKey = $_ENV['CACHE_KEY'];
         $this->assertEquals($envKey, KeyManager::getEncryptionKey());
     }
     
@@ -760,8 +758,8 @@ class SecurityTest extends TestCase {
      */
     public function testCacheSetWithoutEncryptionKey() {
         // Remove encryption key so storeItem falls back to unencrypted storage
-        $originalKey = $_ENV['CACHE_ENCRYPTION_KEY'] ?? null;
-        unset($_ENV['CACHE_ENCRYPTION_KEY']);
+        $originalKey = $_ENV['CACHE_KEY'] ?? null;
+        unset($_ENV['CACHE_KEY']);
         KeyManager::clearCache();
 
         try {
@@ -778,7 +776,7 @@ class SecurityTest extends TestCase {
             }
         } finally {
             if ($originalKey !== null) {
-                $_ENV['CACHE_ENCRYPTION_KEY'] = $originalKey;
+                $_ENV['CACHE_KEY'] = $originalKey;
                 KeyManager::clearCache();
             }
         }
@@ -788,8 +786,8 @@ class SecurityTest extends TestCase {
      * @test
      */
     public function testCacheGetGeneratorWithoutEncryptionKey() {
-        $originalKey = $_ENV['CACHE_ENCRYPTION_KEY'] ?? null;
-        unset($_ENV['CACHE_ENCRYPTION_KEY']);
+        $originalKey = $_ENV['CACHE_KEY'] ?? null;
+        unset($_ENV['CACHE_KEY']);
         KeyManager::clearCache();
 
         try {
@@ -810,7 +808,7 @@ class SecurityTest extends TestCase {
             }
         } finally {
             if ($originalKey !== null) {
-                $_ENV['CACHE_ENCRYPTION_KEY'] = $originalKey;
+                $_ENV['CACHE_KEY'] = $originalKey;
                 KeyManager::clearCache();
             }
         }


### PR DESCRIPTION
# Summary

Add Redis as a built-in cache storage backend via `RedisStorage` class, and simplify encryption key handling across all drivers.

## Motivation

Users requested a Redis backend for production environments where file-based caching is insufficient. Closes #15.

## Changes

- Added `RedisStorage` class implementing the `Storage` interface
- Refactored `KeyManager::getEncryptionKey()` to return `null` instead of throwing when no key is available
- Renamed env var from `CACHE_ENCRYPTION_KEY` to `CACHE_KEY` (with backward-compatible fallback)
- Simplified encryption logic in `Cache::storeItem()` and `FileStorage::readItem()`
- Added `ext-redis` to `composer.json` suggest
- Added `RedisStorageTest` with `@group redis` annotation
- Added runnable example at `examples/advanced/12-redis-storage/`
- Updated all examples and tests to use `CACHE_KEY` env var
- Updated README with Redis section and corrected encryption docs

## How to Test / Verify

- Unit tests: `composer test` (120 tests pass, Redis tests skip gracefully without ext-redis)
- Redis tests: `vendor/bin/phpunit --group redis` (requires ext-redis + Redis server on localhost:6379)
- Example: `php examples/advanced/12-redis-storage/index.php` (requires Redis)

## Breaking Changes and Migration Steps

1. `KeyManager::getEncryptionKey()` return type changed from `string` to `?string`. Code that caught `CacheException` from this method should now check for `null` instead.
2. Environment variable renamed from `CACHE_ENCRYPTION_KEY` to `CACHE_KEY`. The old name still works as a fallback.

## Checklist
- [x] I reviewed my own diff before requesting review
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I added/updated tests (or explained why not)
- [x] I updated docs (if needed) [Docs Repo](https://github.com/WebFiori/docs)
- [x] I ran lint/cs-fixer (if applicable) (`composer fix-cs`)
- [x] I considered backward compatibility
- [x] I considered security

## Related issues

Closes #15